### PR TITLE
feat(CI): restrict PR check to when ready for review

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,4 +1,4 @@
-name: PR Check
+name: PR Check test
 
 on:
   push:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -4,11 +4,16 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    types: [review_requested, ready_for_review]
+    types:
+      - opened
+      - synchronize
+      - ready_for_review
+      - reopened
 
 jobs:
-  check:
+  Test:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,4 +1,4 @@
-name: PR Check test
+name: PR Check
 
 on:
   push:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,6 +1,10 @@
 name: PR Check
 
-on: pull_request
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    types: [review_requested, ready_for_review]
 
 jobs:
   check:


### PR DESCRIPTION
# Description
Restricts PR check to only run when PR is ready for review. i.e. not draft.
Also it will now run for commits on main branch, to verify integration.

Fixes/resolves #24

## Type of change
Please delete options that are not relevant.

- [x] **Improvement** (non-breaking change which improves existing functionality)

# Checklist:
Leave blank if not applicable

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
