### PR TITLE
Add links to backend and frontend to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,23 @@ Core repository for the platform team 4 is developing
 1. Run `yarn` to fetch dependencies.
 2. Run `yarn run start:dev` to simultaneously run the frontend and backend.
 
+**For more information regarding frontend and backend specific development, view the READMEs in their respective folders:**
+
+- [Frontend](packages/frontend)
+- [Backend](packages/backend)
+
 # Running with Docker
 
 Running with Docker will ensure that users can quickly get environment up and running so they can quickly iterate on work. The application will work regardless of operating system and configuration.
 
 ## Web app
-Ensure you have set up backend env files first. Checkout backend README for more info.  
 
-1. Run `yarn run start:docker` to simultaneously run the frontend and backend in docker containers.  
+Ensure you have set up backend env files first. Checkout backend README for more info.
+
+1. Run `yarn run start:docker` to simultaneously run the frontend and backend in docker containers.
 
 ## Tests
 
-1. Run `yarn run test:docker` to simultaneously run the frontend and backend tests in docker containers. 
+1. Run `yarn run test:docker` to simultaneously run the frontend and backend tests in docker containers.
 
 For more detail, view `CONTRIBUTING.md`.


### PR DESCRIPTION
# Description

Adds links to the frontend and backend packages to the main README. The various README files for the project are quite scattered so it is quite easy to miss them.

## Screenshots
![image](https://user-images.githubusercontent.com/25168901/157159076-98187d73-a20d-4372-ac8a-0b7d343fc89a.png)

## Type of change
Please delete options that are not relevant.

- [x] **Improvement** (non-breaking change which improves existing functionality)

# Checklist:
Leave blank if not applicable

I have completed these steps when making this pull request:
- [ ] I have assigned my name to the issue
- [ ] I have moved the issue to the **In Progress** column
- [ ] I have labelled the PR appropriately
- [ ] I have assigned myself to the PR

Before opening the PR for review:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have moved the linked issue to the **Review in Progress** column
