### PR TITLE
Fix sign in not being persisted

### DIFF
--- a/packages/frontend/src/hooks/useAuth.tsx
+++ b/packages/frontend/src/hooks/useAuth.tsx
@@ -5,25 +5,22 @@ interface authContext {
   authLoaded: boolean;
   setAuthLoaded: React.Dispatch<React.SetStateAction<boolean>>;
   signedIn: boolean;
-  setSignedIn: React.Dispatch<React.SetStateAction<boolean>>;
   user: User | null;
   setUser: React.Dispatch<React.SetStateAction<User | null>>;
 }
 
 const AuthContext = createContext<authContext>({
-  authLoaded: true,
+  authLoaded: false,
   setAuthLoaded: () => false,
-  signedIn: false,
-  setSignedIn: () => null,
   user: null,
   setUser: () => null,
+  signedIn: false,
 });
 
 // This context provider is wrapped around the whole project
 // so when the authentication status changes the project re-renders
 export const AuthProvider: React.FC<{}> = ({ children }) => {
-  const [authLoaded, setAuthLoaded] = useState(true);
-  const [signedIn, setSignedIn] = useState(false);
+  const [authLoaded, setAuthLoaded] = useState(false);
   const [user, setUser] = useState<User | null>(null);
 
   return (
@@ -31,10 +28,9 @@ export const AuthProvider: React.FC<{}> = ({ children }) => {
       value={{
         authLoaded,
         setAuthLoaded,
-        signedIn,
-        setSignedIn,
         user,
         setUser,
+        signedIn: !!user,
       }}
     >
       {children}

--- a/packages/frontend/src/pages/public/SignInPage.tsx
+++ b/packages/frontend/src/pages/public/SignInPage.tsx
@@ -1,8 +1,12 @@
 import React from 'react';
 import { auth } from '../../services/firebase';
 import { StyledFirebaseAuth } from 'react-firebaseui';
-import firebase from 'firebase/compat/app';
 import { useAuth } from '../../hooks/useAuth';
+import {
+  GoogleAuthProvider,
+  createUserWithEmailAndPassword,
+  signInWithEmailAndPassword,
+} from 'firebase/auth';
 
 interface SignInPageProps {}
 
@@ -11,13 +15,29 @@ const SignInPage: React.FC<SignInPageProps> = () => {
 
   const uiConfig = {
     signInFlow: 'popup',
-    signInOptions: [firebase.auth.GoogleAuthProvider.PROVIDER_ID],
+    signInOptions: [GoogleAuthProvider.PROVIDER_ID],
     callbacks: {
       signInSuccessWithAuthResult: () => {
         setUser(auth.currentUser);
         return false;
       },
     },
+  };
+
+  const handleCreateEmailAccount = async (email: string, password: string) => {
+    try {
+      await createUserWithEmailAndPassword(auth, email, password);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const handleEmailSignIn = async (email: string, password: string) => {
+    try {
+      await signInWithEmailAndPassword(auth, email, password);
+    } catch (error) {
+      console.error(error);
+    }
   };
 
   return (

--- a/packages/frontend/src/pages/public/SignInPage.tsx
+++ b/packages/frontend/src/pages/public/SignInPage.tsx
@@ -7,17 +7,14 @@ import { useAuth } from '../../hooks/useAuth';
 interface SignInPageProps {}
 
 const SignInPage: React.FC<SignInPageProps> = () => {
-  const { setSignedIn, setUser } = useAuth();
+  const { setUser } = useAuth();
 
   const uiConfig = {
     signInFlow: 'popup',
     signInOptions: [firebase.auth.GoogleAuthProvider.PROVIDER_ID],
     callbacks: {
       signInSuccessWithAuthResult: () => {
-        setSignedIn(true);
-        const R = require('ramda');
-        const userParam = R.pickAll(['displayName', 'email'], auth.currentUser);
-        setUser(userParam);
+        setUser(auth.currentUser);
         return false;
       },
     },

--- a/packages/frontend/src/pages/routes/AuthenticatedRoutes.tsx
+++ b/packages/frontend/src/pages/routes/AuthenticatedRoutes.tsx
@@ -2,12 +2,14 @@ import React from 'react';
 import { Routes } from 'react-router';
 import { Navigate, Route } from 'react-router-dom';
 import HomePage from '../public/HomePage';
+import LandingPage from '../public/LandingPage';
 
 interface AuthenticatedRoutesProps {}
 
 const AuthenticatedRoutes: React.FC<AuthenticatedRoutesProps> = () => {
   return (
     <Routes>
+      <Route path="landing" element={<LandingPage />} />
       <Route path="home" element={<HomePage />} />
       <Route path="*" element={<Navigate to="/home" replace />} />
     </Routes>

--- a/packages/frontend/src/pages/routes/Router.tsx
+++ b/packages/frontend/src/pages/routes/Router.tsx
@@ -7,18 +7,20 @@ import { useAuth } from '../../hooks/useAuth';
 interface RouterProps {}
 
 const Router: React.FC<RouterProps> = () => {
-  const { authLoaded, setAuthLoaded, signedIn, setUser } = useAuth();
+  const { authLoaded, setAuthLoaded, setUser, signedIn } = useAuth();
 
   useEffect(() => {
     // returns function to stop the listener
     const clearListener = getAuth().onAuthStateChanged((user) => {
-      setAuthLoaded(true);
       setUser(user);
+      setAuthLoaded(true);
     });
     return () => {
       clearListener();
     };
   }, [setAuthLoaded, setUser]);
+
+  console.log({ authLoaded, signedIn });
 
   if (!authLoaded) {
     return null;


### PR DESCRIPTION
# Description
Change the auth logic to correctly persist login state (users were still logged in, but this wasn't reflected in the `useAuth` hook).

This PR will also introduce functions that support email sign in.

Fixes/resolves #66 

## Type of change

- [X] **Bug fix** (non-breaking change which fixes an issue)

# Checklist:
Leave blank if not applicable

I have completed these steps when making this pull request:
- [x] I have assigned my name to the issue
- [x] I have moved the issue to the **In Progress** column
- [x] I have labelled the PR appropriately
- [x] I have assigned myself to the PR

Before opening the PR for review:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings (warnings for unused functions that will be used later)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have moved the linked issue to the **Review in Progress** column
