### PR TITLE
Update GET /house api endpoint to return 404 if no house found

### DIFF
--- a/packages/backend/src/controllers/house/house.controller.spec.ts
+++ b/packages/backend/src/controllers/house/house.controller.spec.ts
@@ -50,7 +50,7 @@ describe('HouseController', () => {
     } as UserDocument);
 
     expect(() => controller.getHouse(userToken)).rejects.toThrow(
-      new HttpException('user is not in a house', HttpStatus.NOT_FOUND),
+      new HttpException('user is not in a house', HttpStatus.NO_CONTENT),
     );
   });
 });

--- a/packages/backend/src/controllers/house/house.controller.spec.ts
+++ b/packages/backend/src/controllers/house/house.controller.spec.ts
@@ -1,26 +1,56 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { getModelToken } from '@nestjs/mongoose';
 import { Test, TestingModule } from '@nestjs/testing';
+import { Types } from 'mongoose';
+import { House, HouseDocument } from '../../db/house/house.schema';
+import { User, UserDocument } from '../../db/user/user.schema';
 import { UserStoreService } from '../../db/user/userStore.service';
 import { HouseStoreService } from '../../db/house/houseStore.service';
+import { getFakeUserToken, mockModel } from '../../util/testing.utils';
 import { HouseController } from './house.controller';
 import { HouseUtil } from './house.util';
 
 describe('HouseController', () => {
   let controller: HouseController;
+  let userStoreService: UserStoreService;
+  let houseStoreService: HouseStoreService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [HouseController],
       providers: [
-        { provide: HouseStoreService, useValue: {} },
-        { provide: UserStoreService, useValue: {} },
-        { provide: HouseUtil, useValue: {} },
+        HouseStoreService,
+        UserStoreService,
+        HouseUtil,
+        {
+          provide: getModelToken(User.name),
+          useValue: mockModel,
+        },
+        {
+          provide: getModelToken(House.name),
+          useValue: mockModel,
+        },
       ],
     }).compile();
 
+    userStoreService = module.get<UserStoreService>(UserStoreService);
+    houseStoreService = module.get<HouseStoreService>(HouseStoreService);
     controller = module.get<HouseController>(HouseController);
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  it('should return 404 with getHouse if user does not have a house linked', () => {
+    const userToken = getFakeUserToken();
+    jest.spyOn(userStoreService, 'findOneByFirebaseId').mockResolvedValue({
+      house: undefined,
+      firebaseId: userToken.uid,
+    } as UserDocument);
+
+    expect(() => controller.getHouse(userToken)).rejects.toThrow(
+      new HttpException('user is not in a house', HttpStatus.NOT_FOUND),
+    );
   });
 });

--- a/packages/backend/src/controllers/house/house.controller.spec.ts
+++ b/packages/backend/src/controllers/house/house.controller.spec.ts
@@ -42,7 +42,7 @@ describe('HouseController', () => {
     expect(controller).toBeDefined();
   });
 
-  it('should return 201 with getHouse if user does not have a house linked', () => {
+  it('should return 204 with getHouse if user does not have a house linked', () => {
     const userToken = getFakeUserToken();
     jest.spyOn(userStoreService, 'findOneByFirebaseId').mockResolvedValue({
       house: undefined,

--- a/packages/backend/src/controllers/house/house.controller.spec.ts
+++ b/packages/backend/src/controllers/house/house.controller.spec.ts
@@ -42,7 +42,7 @@ describe('HouseController', () => {
     expect(controller).toBeDefined();
   });
 
-  it('should return 404 with getHouse if user does not have a house linked', () => {
+  it('should return 201 with getHouse if user does not have a house linked', () => {
     const userToken = getFakeUserToken();
     jest.spyOn(userStoreService, 'findOneByFirebaseId').mockResolvedValue({
       house: undefined,

--- a/packages/backend/src/controllers/house/house.controller.ts
+++ b/packages/backend/src/controllers/house/house.controller.ts
@@ -68,6 +68,7 @@ export class HouseController {
     description: 'house retrieved successfully',
     type: HouseResponseDto,
   })
+  @ApiNotFoundResponse({ description: 'user is not in a house' })
   async getHouse(
     @User() user: DecodedIdToken,
   ): Promise<HouseResponseDto | null> {
@@ -82,7 +83,7 @@ export class HouseController {
         name: house.name,
       };
     } else {
-      return null;
+      throw new HttpException('user is not in a house', HttpStatus.NOT_FOUND);
     }
   }
 
@@ -114,10 +115,6 @@ export class HouseController {
         owner: owner.firebaseId,
         name: house.name,
       };
-    } else
-      throw new HttpException(
-        'the house could not be found',
-        HttpStatus.NOT_FOUND,
-      );
+    } else throw new HttpException('code is invalid', HttpStatus.NOT_FOUND);
   }
 }

--- a/packages/backend/src/controllers/house/house.controller.ts
+++ b/packages/backend/src/controllers/house/house.controller.ts
@@ -10,7 +10,7 @@ import {
 import {
   ApiBadRequestResponse,
   ApiCreatedResponse,
-  ApiNotFoundResponse,
+  ApiNoContentResponse,
   ApiOkResponse,
   ApiOperation,
   ApiTags,
@@ -68,7 +68,7 @@ export class HouseController {
     description: 'house retrieved successfully',
     type: HouseResponseDto,
   })
-  @ApiNotFoundResponse({ description: 'user is not in a house' })
+  @ApiNoContentResponse({ description: 'user is not in a house' })
   async getHouse(
     @User() user: DecodedIdToken,
   ): Promise<HouseResponseDto | null> {
@@ -86,7 +86,7 @@ export class HouseController {
       }
     }
 
-    throw new HttpException('user is not in a house', HttpStatus.NOT_FOUND);
+    throw new HttpException('user is not in a house', HttpStatus.NO_CONTENT);
   }
 
   @Put()

--- a/packages/backend/src/util/testing.utils.ts
+++ b/packages/backend/src/util/testing.utils.ts
@@ -1,0 +1,30 @@
+import { randomUUID } from 'crypto';
+import { DecodedIdToken } from 'firebase-admin/auth';
+
+export function getFakeUserToken(
+  options?: Partial<DecodedIdToken>,
+): DecodedIdToken {
+  const uid = '36b8f84d-df4e-4d49-b662-bcde71a8764f';
+  const tokenBase: DecodedIdToken = {
+    uid,
+    aud: 'my-project',
+    auth_time: 1647112806300,
+    exp: 2530725606300, //2050
+    iss: 'https://securetoken.google.com/my-project',
+    iat: 1647112986000,
+    sub: uid,
+    firebase: {
+      sign_in_provider: 'password',
+      identities: {},
+    },
+  };
+
+  return { ...tokenBase, ...options };
+}
+
+export const mockModel = {
+  create: jest.fn(),
+  updateOne: jest.fn(),
+  deleteOne: jest.fn(),
+  findOne: jest.fn(),
+};


### PR DESCRIPTION
# Description
- `GET /api/v1/house` now returns http status `404` if no house was found
- changed the error message in `PUT /api/v1/house` from `the house could not be found` to `code is invalid`

Fixes/resolves #77 

## Screenshots
![image](https://user-images.githubusercontent.com/7777317/158031531-ab9ddc18-0354-4ad1-aca1-c6beeed6a00d.png)

## Type of change
- [x] **Bug fix** (non-breaking change which fixes an issue)

# Checklist:
Leave blank if not applicable

I have completed these steps when making this pull request:
- [x] I have assigned my name to the issue
- [x] I have moved the issue to the **In Progress** column
- [x] I have labelled the PR appropriately
- [x] I have assigned myself to the PR

Before opening the PR for review:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have moved the linked issue to the **Review in Progress** column
