### PR TITLE
Disable lfs.locksverify on postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "husky": "^7.0.4",
     "lerna": "^4.0.0",
     "lint-staged": "^12.3.4",
+    "npm-run-all": "^4.1.5",
     "prettier": "^2.5.1"
   },
   "lint-staged": {
@@ -13,11 +14,13 @@
   "scripts": {
     "build": "lerna run build",
     "prepare": "husky install",
-    "postinstall": "lerna bootstrap",
     "start": "lerna run --parallel start",
     "start:dev": "lerna run --parallel start:dev",
     "test": "lerna run --parallel test",
     "start:docker": "docker-compose -f docker-compose.yaml up",
-    "test:docker": "docker-compose -f docker-compose.override.yaml up"
+    "test:docker": "docker-compose -f docker-compose.override.yaml up",
+    "postinstall": "run-s setup:*",
+    "setup:npm": "lerna bootstrap",
+    "setup:git": "git config lfs.locksverify false"
   }
 }


### PR DESCRIPTION
# Description

Having lfs.locsverify enabled causes authentication issues on other people's forks. This will disable this option when someone sets up the repo.

Fixes #96 

## Type of change
Please delete options that are not relevant.

- [X] **Bug fix** (non-breaking change which fixes an issue)

# Checklist:
Leave blank if not applicable

I have completed these steps when making this pull request:
- [x] I have assigned my name to the issue
- [x] I have moved the issue to the **In Progress** column
- [x] I have labelled the PR appropriately
- [x] I have assigned myself to the PR

Before opening the PR for review:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have moved the linked issue to the **Review in Progress** column
