### PR TITLE
Create Announcement Modal Form component (new)

### DIFF
--- a/packages/frontend/src/components/announcement/AnnouncementModalForm.tsx
+++ b/packages/frontend/src/components/announcement/AnnouncementModalForm.tsx
@@ -1,0 +1,63 @@
+import { Button, Modal } from '@nextui-org/react';
+import React, { useRef } from 'react';
+
+interface AnnouncementModalFormProps {
+  visible: boolean;
+  setVisible: React.Dispatch<React.SetStateAction<boolean>>;
+  onSaveAnnouncement: (title: string, detail: string) => void;
+}
+
+const AnnouncementModalForm: React.FC<AnnouncementModalFormProps> = (props) => {
+  const titleRef = useRef() as React.MutableRefObject<HTMLInputElement>;
+  const detailRef = useRef() as React.MutableRefObject<HTMLInputElement>;
+
+  const handlePublish = () => {
+    props.onSaveAnnouncement(
+      titleRef.current.textContent || '',
+      detailRef.current.textContent || '',
+    );
+    props.setVisible(false);
+  };
+
+  return (
+    <>
+      <Modal
+        scroll
+        closeButton
+        open={props.visible}
+        onClose={() => props.setVisible(false)}
+        width={'70%'}
+      >
+        <Modal.Header>
+          <span
+            className="w-full text-2xl font-bold text-left hover:text-gray-500 focus:text-black outline-none"
+            contentEditable={true}
+            suppressContentEditableWarning={true}
+            ref={titleRef}
+          >
+            Enter a title for your announcement
+          </span>
+        </Modal.Header>
+        <Modal.Body>
+          <div>
+            <span
+              className="block hover:text-gray-500 h-[50vh] focus:text-black outline-none"
+              suppressContentEditableWarning={true}
+              contentEditable={true}
+              ref={detailRef}
+            >
+              Details
+            </span>
+          </div>
+        </Modal.Body>
+        <Modal.Footer>
+          <div className="flex justify-end">
+            <Button onClick={handlePublish}>Publish</Button>
+          </div>
+        </Modal.Footer>
+      </Modal>
+    </>
+  );
+};
+
+export default AnnouncementModalForm;


### PR DESCRIPTION
# Description
Fixes/resolves #166 

Refer to the video to see the frontend interactions with the modal. 
- The component comes with a button for modal trigger
- When you hover over the modal pane, the text changes to grey to indicate to the user clearly that the text is editable
- The text cursor means that it's pretty obvious the modal texts are editable (see video)
- You can pass a callback of `(title:string, detail:string)=>void` to `onSaveAnnouncement` prop to the modal component.

## Screenshots

https://user-images.githubusercontent.com/68993476/160854400-81a6c1ea-1485-4882-88f7-1326e6df3dd2.mov


## Type of change

Please delete options that are not relevant.
- [x] **New feature** (non-breaking change which adds functionality)

# Checklist:
I have completed these steps when making this pull request:

- [x] I have assigned my name to the issue
- [x] I have moved the issue to the **In Progress** column
- [x] I have labelled the PR appropriately
- [x] I have assigned myself to the PR

Before opening the PR for review:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added attributions to new dependencies and resources
- [x] I have moved the linked issue to the **Review in Progress** column
