### PR TITLE
Link Edit Note page to backend

### DIFF
--- a/packages/backend/src/controllers/note/dto/note-response.dto.ts
+++ b/packages/backend/src/controllers/note/dto/note-response.dto.ts
@@ -2,7 +2,9 @@ import { ApiProperty } from '@nestjs/swagger';
 import { NoteContents } from '../../../db/note/note.schema';
 import { Types } from 'mongoose';
 
-export default class NoteResponseDto {
+export class NoteResponseDto {
+  @ApiProperty()
+  id: string;
   @ApiProperty()
   name: string;
   @ApiProperty()
@@ -11,4 +13,11 @@ export default class NoteResponseDto {
   type: NoteContents;
   @ApiProperty()
   house: Types.ObjectId;
+}
+
+export class NotesResponseDto {
+  @ApiProperty({
+    type: [NoteResponseDto],
+  })
+  notes: NoteResponseDto[];
 }

--- a/packages/backend/src/controllers/note/note.controller.spec.ts
+++ b/packages/backend/src/controllers/note/note.controller.spec.ts
@@ -8,7 +8,7 @@ import { NoteStoreService } from '../../db/note/noteStore.service';
 import { UserStoreService } from '../../db/user/userStore.service';
 import { NoteController } from './note.controller';
 import { getModelToken } from '@nestjs/mongoose';
-
+import { NoteUtil } from './note.utils';
 import { mockModel } from '../../util/testing.utils';
 
 describe('HouseController', () => {
@@ -36,6 +36,7 @@ describe('HouseController', () => {
           provide: getModelToken(Note.name),
           useValue: mockModel,
         },
+        NoteUtil,
       ],
     }).compile();
 

--- a/packages/backend/src/controllers/note/note.module.ts
+++ b/packages/backend/src/controllers/note/note.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
 import { NoteController } from './note.controller';
 import { DbModule } from '../../db/db.module';
+import { NoteUtil } from './note.utils';
 
 @Module({
   controllers: [NoteController],
   imports: [DbModule],
+  providers: [NoteUtil],
 })
 export class NoteModule {}

--- a/packages/backend/src/controllers/note/note.utils.ts
+++ b/packages/backend/src/controllers/note/note.utils.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import { NoteDocument } from 'src/db/note/note.schema';
+import { NoteResponseDto } from './dto/note-response.dto';
+
+@Injectable()
+export class NoteUtil {
+  async covertNoteDocumentToResponseDTO(
+    noteDocumet: NoteDocument,
+  ): Promise<NoteResponseDto> {
+    return {
+      id: noteDocumet._id,
+      name: noteDocumet.name,
+      value: noteDocumet.value,
+      type: noteDocumet.type,
+      house: noteDocumet.house,
+    };
+  }
+}

--- a/packages/backend/src/db/note/noteStore.service.ts
+++ b/packages/backend/src/db/note/noteStore.service.ts
@@ -28,10 +28,7 @@ export class NoteStoreService {
   async findAllByHouse(
     houseId: string | Mongoose.Types.ObjectId,
   ): Promise<NoteDocument[]> {
-    return this.noteModel
-      .find()
-      .populate({ path: 'house', match: { _id: houseId } })
-      .exec();
+    return this.noteModel.find({ house: houseId }).exec();
   }
 
   async update(

--- a/packages/frontend/src/components/notes/note/NotesGrid.tsx
+++ b/packages/frontend/src/components/notes/note/NotesGrid.tsx
@@ -26,6 +26,7 @@ const NotesGrid: React.FC<NotesGridProps> = ({ notes }) => {
   const [qrCodeText, setQrCodeText] = useState('');
   const [qrvisible, setQRVisible] = useState(false);
   const [loading] = useState(false);
+
   const onClickCard = (item: any) => {
     switch (item.type) {
       case 'PLAIN':
@@ -46,8 +47,10 @@ const NotesGrid: React.FC<NotesGridProps> = ({ notes }) => {
         visible={plainvisible}
         setVisible={setPlainVisible}
         loading={loading}
-        data={activeValue}
+        value={activeValue}
+        setValue={setActiveValue}
         title={activeName}
+        setTitle={setActiveName}
         id={activeId}
       />
 
@@ -58,10 +61,12 @@ const NotesGrid: React.FC<NotesGridProps> = ({ notes }) => {
         qrCodeText={qrCodeText}
         loading={loading}
         value={activeValue}
+        setValue={setActiveValue}
         encryption={'L'}
         qrvisible={qrvisible}
         setQRVisible={setQRVisible}
         title={activeName}
+        setTitle={setActiveName}
         id={activeId}
       />
 
@@ -69,8 +74,10 @@ const NotesGrid: React.FC<NotesGridProps> = ({ notes }) => {
         visible={secretvisible}
         setVisible={setSecretVisible}
         loading={loading}
-        data={activeValue}
+        value={activeValue}
+        setValue={setActiveValue}
         title={activeName}
+        setTitle={setActiveName}
         id={activeId}
       />
 

--- a/packages/frontend/src/components/notes/note/NotesGrid.tsx
+++ b/packages/frontend/src/components/notes/note/NotesGrid.tsx
@@ -5,8 +5,9 @@ import PlainModal from './plainModal';
 import SecretModal from './secretModal';
 
 interface NotesGridProps {
-  Notes:
+  notes:
     | {
+        id: string;
         name: string;
         value: string;
         type: string;
@@ -15,12 +16,13 @@ interface NotesGridProps {
     | undefined;
 }
 
-const NotesGrid: React.FC<NotesGridProps> = ({ Notes }) => {
+const NotesGrid: React.FC<NotesGridProps> = ({ notes }) => {
   const [plainvisible, setPlainVisible] = useState(false);
   const [secretvisible, setSecretVisible] = useState(false);
   const [wifivisible, setWifiVisible] = useState(false);
   const [activeName, setActiveName] = useState('');
   const [activeValue, setActiveValue] = useState('');
+  const [activeId, setActiveId] = useState('');
   const [qrCodeText, setQrCodeText] = useState('');
   const [qrvisible, setQRVisible] = useState(false);
   const [loading] = useState(false);
@@ -46,6 +48,7 @@ const NotesGrid: React.FC<NotesGridProps> = ({ Notes }) => {
         loading={loading}
         data={activeValue}
         title={activeName}
+        id={activeId}
       />
 
       <WifiModal
@@ -59,6 +62,7 @@ const NotesGrid: React.FC<NotesGridProps> = ({ Notes }) => {
         qrvisible={qrvisible}
         setQRVisible={setQRVisible}
         title={activeName}
+        id={activeId}
       />
 
       <SecretModal
@@ -67,10 +71,11 @@ const NotesGrid: React.FC<NotesGridProps> = ({ Notes }) => {
         loading={loading}
         data={activeValue}
         title={activeName}
+        id={activeId}
       />
 
       <Grid.Container gap={2} justify="center">
-        {Notes?.map((item, index) => (
+        {notes?.map((item, index) => (
           <Grid xs={18} md={6} sm={6} key={index}>
             <Card
               color="secondary"
@@ -79,6 +84,7 @@ const NotesGrid: React.FC<NotesGridProps> = ({ Notes }) => {
               onClick={(event) => {
                 setActiveName(item.name);
                 setActiveValue(item.value);
+                setActiveId(item.id);
                 onClickCard(item);
               }}
             >
@@ -92,6 +98,7 @@ const NotesGrid: React.FC<NotesGridProps> = ({ Notes }) => {
                 weight="semibold"
               >
                 {item.type}
+                {item.id}
               </Text>
             </Card>
           </Grid>

--- a/packages/frontend/src/components/notes/note/NotesGrid.tsx
+++ b/packages/frontend/src/components/notes/note/NotesGrid.tsx
@@ -105,7 +105,6 @@ const NotesGrid: React.FC<NotesGridProps> = ({ notes }) => {
                 weight="semibold"
               >
                 {item.type}
-                {item.id}
               </Text>
             </Card>
           </Grid>

--- a/packages/frontend/src/components/notes/note/editButton.tsx
+++ b/packages/frontend/src/components/notes/note/editButton.tsx
@@ -5,14 +5,18 @@ import EditNoteModal from './editNoteModal';
 
 interface EditButtonProps {
   activeTitle: string;
+  setTitle: (value: string) => void;
   activeValue: string;
+  setValue: (value: string) => void;
   activeType: string;
   activeId: string;
 }
 
 const EditButton: React.FC<EditButtonProps> = ({
   activeTitle,
+  setTitle,
   activeValue,
+  setValue,
   activeType,
   activeId,
 }) => {
@@ -31,7 +35,9 @@ const EditButton: React.FC<EditButtonProps> = ({
       />
       <EditNoteModal
         activeTitle={activeTitle}
+        setTitle={setTitle}
         activeValue={activeValue}
+        setValue={setValue}
         activeType={activeType}
         activeId={activeId}
         editNoteVisible={editNoteVisible}

--- a/packages/frontend/src/components/notes/note/editButton.tsx
+++ b/packages/frontend/src/components/notes/note/editButton.tsx
@@ -7,12 +7,14 @@ interface EditButtonProps {
   activeTitle: string;
   activeValue: string;
   activeType: string;
+  activeId: string;
 }
 
 const EditButton: React.FC<EditButtonProps> = ({
   activeTitle,
   activeValue,
   activeType,
+  activeId,
 }) => {
   const [editNoteVisible, setEditNoteVisible] = useState(false);
   const editNoteHandler = () => setEditNoteVisible(true);
@@ -31,6 +33,7 @@ const EditButton: React.FC<EditButtonProps> = ({
         activeTitle={activeTitle}
         activeValue={activeValue}
         activeType={activeType}
+        activeId={activeId}
         editNoteVisible={editNoteVisible}
         setEditNoteVisible={setEditNoteVisible}
       />

--- a/packages/frontend/src/components/notes/note/editNoteModal.tsx
+++ b/packages/frontend/src/components/notes/note/editNoteModal.tsx
@@ -12,7 +12,7 @@ import {
   Textarea,
 } from '@nextui-org/react';
 
-const noteType = ['Normal', 'Secret', 'WiFi'];
+const noteType = ['PLAIN', 'SECRET', 'WiFi'];
 
 interface EditNoteModalProps {
   editNoteVisible: boolean;
@@ -20,6 +20,7 @@ interface EditNoteModalProps {
   activeTitle: string;
   activeValue: string;
   activeType: string;
+  activeId: string;
 }
 
 const EditNoteModal: React.FC<EditNoteModalProps> = ({
@@ -28,6 +29,7 @@ const EditNoteModal: React.FC<EditNoteModalProps> = ({
   activeTitle,
   activeValue,
   activeType,
+  activeId,
 }) => {
   const closeNoteHandler = () => setEditNoteVisible(false);
   const [selected, setSelected] = useState(activeType);
@@ -38,16 +40,17 @@ const EditNoteModal: React.FC<EditNoteModalProps> = ({
     type: string;
   }
   const [editedNote, setEditedNote] = useState<tempNote>({
-    title: 'string;',
-    value: 'string;',
-    type: 'string;',
+    title: activeTitle,
+    value: activeValue,
+    type: activeType,
   });
 
   const editNote = useApiMutation('/api/v1/house/note/{id}', { method: 'put' });
 
   const saveCaller = async () => {
+    console.log(editedNote);
     await editNote({
-      pathParams: { id: 1 ?? '' },
+      pathParams: { id: activeId },
       body: {
         name: editedNote.title,
         value: editedNote.value,

--- a/packages/frontend/src/components/notes/note/noteCardController.tsx
+++ b/packages/frontend/src/components/notes/note/noteCardController.tsx
@@ -5,14 +5,16 @@ import { useApi, useApiMutation } from '../../../hooks/useApi';
 
 interface NoteCardControllerProps {}
 
-const NoteCardController: React.FC<NoteCardControllerProps> = () => {
-  enum NoteTypes {
-    PLAIN = 'PLAIN',
-    SECRET = 'SECRET',
-    WIFI = 'WIFI',
-  }
+export enum NoteTypes {
+  PLAIN = 'PLAIN',
+  SECRET = 'SECRET',
+  WIFI = 'WIFI',
+}
 
+const NoteCardController: React.FC<NoteCardControllerProps> = () => {
   const { data, mutate } = useApi('/api/v1/house/note', { method: 'get' });
+
+  console.log(data);
 
   const createNote = useApiMutation('/api/v1/house/note', { method: 'post' });
 
@@ -34,7 +36,7 @@ const NoteCardController: React.FC<NoteCardControllerProps> = () => {
 
   return (
     <div>
-      <NotesModal Notes={data} />
+      <NotesModal notes={data?.notes} />
       <Button onClick={onClickTest}>Test</Button>
     </div>
   );

--- a/packages/frontend/src/components/notes/note/noteCardController.tsx
+++ b/packages/frontend/src/components/notes/note/noteCardController.tsx
@@ -14,8 +14,6 @@ export enum NoteTypes {
 const NoteCardController: React.FC<NoteCardControllerProps> = () => {
   const { data, mutate } = useApi('/api/v1/house/note', { method: 'get' });
 
-  console.log(data);
-
   const createNote = useApiMutation('/api/v1/house/note', { method: 'post' });
 
   // temp data to test api fetch works

--- a/packages/frontend/src/components/notes/note/plainModal.tsx
+++ b/packages/frontend/src/components/notes/note/plainModal.tsx
@@ -14,8 +14,10 @@ interface PlainModalProps {
   visible: boolean;
   setVisible(value: boolean): void;
   loading: boolean;
-  data: string;
+  value: string;
+  setValue(value: string): void;
   title: string;
+  setTitle(value: string): void;
   id: string;
 }
 
@@ -23,8 +25,10 @@ const PlainModal: React.FC<PlainModalProps> = ({
   visible,
   setVisible,
   loading,
-  data,
+  value,
+  setValue,
   title,
+  setTitle,
   id,
 }) => {
   const closeHandler = () => {
@@ -61,7 +65,9 @@ const PlainModal: React.FC<PlainModalProps> = ({
             ) : (
               <EditButton
                 activeTitle={title}
-                activeValue={data}
+                setTitle={setTitle}
+                activeValue={value}
+                setValue={setValue}
                 activeType={NoteTypes.PLAIN}
                 activeId={id}
               />
@@ -79,7 +85,7 @@ const PlainModal: React.FC<PlainModalProps> = ({
               justify="space-between"
               css={{ p: 0 }}
             >
-              <Text id="modal-title">{data}</Text>
+              <Text id="modal-title">{value}</Text>
             </Container>
           )}
         </Modal.Body>

--- a/packages/frontend/src/components/notes/note/plainModal.tsx
+++ b/packages/frontend/src/components/notes/note/plainModal.tsx
@@ -8,6 +8,7 @@ import {
   Text,
 } from '@nextui-org/react';
 import EditButton from './editButton';
+import { NoteTypes } from './noteCardController';
 
 interface PlainModalProps {
   visible: boolean;
@@ -15,6 +16,7 @@ interface PlainModalProps {
   loading: boolean;
   data: string;
   title: string;
+  id: string;
 }
 
 const PlainModal: React.FC<PlainModalProps> = ({
@@ -23,6 +25,7 @@ const PlainModal: React.FC<PlainModalProps> = ({
   loading,
   data,
   title,
+  id,
 }) => {
   const closeHandler = () => {
     setVisible(false);
@@ -59,7 +62,8 @@ const PlainModal: React.FC<PlainModalProps> = ({
               <EditButton
                 activeTitle={title}
                 activeValue={data}
-                activeType={'Normal'}
+                activeType={NoteTypes.PLAIN}
+                activeId={id}
               />
             )}
           </Container>

--- a/packages/frontend/src/components/notes/note/secretModal.tsx
+++ b/packages/frontend/src/components/notes/note/secretModal.tsx
@@ -11,6 +11,7 @@ import {
 } from '@nextui-org/react';
 import React, { useState } from 'react';
 import EditButton from './editButton';
+import { NoteTypes } from './noteCardController';
 
 interface SecretModalProps {
   visible: boolean;
@@ -18,6 +19,7 @@ interface SecretModalProps {
   loading: boolean;
   data: string;
   title: string;
+  id: string;
 }
 
 const SecretModal: React.FC<SecretModalProps> = ({
@@ -26,6 +28,7 @@ const SecretModal: React.FC<SecretModalProps> = ({
   loading,
   data,
   title,
+  id,
 }) => {
   const [passwordShown, setPasswordShown] = useState(true);
 
@@ -68,7 +71,8 @@ const SecretModal: React.FC<SecretModalProps> = ({
               <EditButton
                 activeTitle={title}
                 activeValue={data}
-                activeType={'Secret'}
+                activeType={NoteTypes.SECRET}
+                activeId={id}
               />
             )}
           </Container>

--- a/packages/frontend/src/components/notes/note/secretModal.tsx
+++ b/packages/frontend/src/components/notes/note/secretModal.tsx
@@ -17,8 +17,10 @@ interface SecretModalProps {
   visible: boolean;
   setVisible(value: boolean): void;
   loading: boolean;
-  data: string;
+  value: string;
+  setValue(value: string): void;
   title: string;
+  setTitle(value: string): void;
   id: string;
 }
 
@@ -26,8 +28,10 @@ const SecretModal: React.FC<SecretModalProps> = ({
   visible,
   setVisible,
   loading,
-  data,
+  value,
+  setValue,
   title,
+  setTitle,
   id,
 }) => {
   const [passwordShown, setPasswordShown] = useState(true);
@@ -70,7 +74,9 @@ const SecretModal: React.FC<SecretModalProps> = ({
             ) : (
               <EditButton
                 activeTitle={title}
-                activeValue={data}
+                setTitle={setTitle}
+                activeValue={value}
+                setValue={setValue}
                 activeType={NoteTypes.SECRET}
                 activeId={id}
               />
@@ -93,10 +99,10 @@ const SecretModal: React.FC<SecretModalProps> = ({
                   readOnly
                   width="100%"
                   type={passwordShown ? 'password' : 'text'}
-                  initialValue={data}
+                  initialValue={value}
                 />
               ) : (
-                <Text id="modal-description">{data}</Text>
+                <Text id="modal-description">{value}</Text>
               )}
             </Container>
           )}

--- a/packages/frontend/src/components/notes/note/wifiModal.tsx
+++ b/packages/frontend/src/components/notes/note/wifiModal.tsx
@@ -12,6 +12,7 @@ import {
 import React, { useState } from 'react';
 import QRCode from 'react-qr-code';
 import EditButton from './editButton';
+import { NoteTypes } from './noteCardController';
 
 interface WifiModalProps {
   visible: boolean;
@@ -23,6 +24,7 @@ interface WifiModalProps {
   qrCodeText: string;
   qrvisible: boolean;
   title: string;
+  id: string;
   setQRVisible(value: boolean): void;
 }
 
@@ -37,6 +39,7 @@ const WifiModal: React.FC<WifiModalProps> = ({
   qrvisible,
   setQRVisible,
   title,
+  id,
 }) => {
   const closeHandler = () => {
     setVisible(false);
@@ -105,7 +108,8 @@ const WifiModal: React.FC<WifiModalProps> = ({
               <EditButton
                 activeTitle={title}
                 activeValue={value}
-                activeType={'WiFi'}
+                activeType={NoteTypes.WIFI}
+                activeId={id}
               />
             )}
           </Container>

--- a/packages/frontend/src/components/notes/note/wifiModal.tsx
+++ b/packages/frontend/src/components/notes/note/wifiModal.tsx
@@ -20,10 +20,12 @@ interface WifiModalProps {
   setQrCodeText(value: string): void;
   loading: boolean;
   value: string;
+  setValue(value: string): void;
   encryption: string;
   qrCodeText: string;
   qrvisible: boolean;
   title: string;
+  setTitle(value: string): void;
   id: string;
   setQRVisible(value: boolean): void;
 }
@@ -34,11 +36,13 @@ const WifiModal: React.FC<WifiModalProps> = ({
   setQrCodeText,
   loading,
   value,
+  setValue,
   encryption,
   qrCodeText,
   qrvisible,
   setQRVisible,
   title,
+  setTitle,
   id,
 }) => {
   const closeHandler = () => {
@@ -107,7 +111,9 @@ const WifiModal: React.FC<WifiModalProps> = ({
             ) : (
               <EditButton
                 activeTitle={title}
+                setTitle={setTitle}
                 activeValue={value}
+                setValue={setValue}
                 activeType={NoteTypes.WIFI}
                 activeId={id}
               />

--- a/packages/frontend/src/types/api-schema.ts
+++ b/packages/frontend/src/types/api-schema.ts
@@ -108,10 +108,14 @@ export interface components {
     };
     ObjectId: { [key: string]: unknown };
     NoteResponseDto: {
+      id: string;
       name: string;
       value: string;
       type: string;
       house: components['schemas']['ObjectId'];
+    };
+    NotesResponseDto: {
+      notes: components['schemas']['NoteResponseDto'][];
     };
     UpdateNoteDto: {
       name: string;
@@ -306,7 +310,7 @@ export interface operations {
       /** notes retrieved successfully */
       200: {
         content: {
-          'application/json': components['schemas']['NoteResponseDto'][];
+          'application/json': components['schemas']['NotesResponseDto'];
         };
       };
       /** user does not belong to a house */


### PR DESCRIPTION
# Description

* Edit note page is now linked to the backend
* Updates to notes are reflected in the database and on the note page
* Adjusted backend and frontend type declarations to include 'id' to be used when updating the notes with PUT
* Only shows notes related to the house instead of all notes in the database
* Known bug: note type does not automatically change when updating note. Must click out of note modal to see updated type

Fixes/resolves # (issue)
Relates to #85 

## Screenshots

## Type of change

Please delete options that are not relevant.

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

Leave blank if not applicable

I have completed these steps when making this pull request:

- [x] I have assigned my name to the issue
- [x] I have moved the issue to the **In Progress** column
- [x] I have labelled the PR appropriately
- [x] I have assigned myself to the PR

Before opening the PR for review:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added attributions to new dependencies and resources
- [x] I have moved the linked issue to the **Review in Progress** column
