### PR TITLE
Add a back button to existing pages

### DIFF
--- a/packages/frontend/src/components/common/layout/Navigation.tsx
+++ b/packages/frontend/src/components/common/layout/Navigation.tsx
@@ -1,13 +1,18 @@
 import React from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { Button } from '@nextui-org/react';
 import AppLogo from '../util/AppLogo';
 import UserDisplay from '../util/UserDisplay';
-import { useNavigate } from 'react-router-dom';
-import { Button } from '@nextui-org/react';
+import BackButton from '../util/BackButton';
 
-interface NavigationProps {}
+interface NavigationProps {
+  backpath?: string;
+}
 
-const Navigation: React.FC<NavigationProps> = () => {
+const Navigation: React.FC<NavigationProps> = ({ backpath }) => {
   const navigate = useNavigate();
+  const location = useLocation();
+
   return (
     <div className="p-4 mb-8 shadow bg-slate-50">
       <div className="flex items-center justify-between mx-10">
@@ -17,7 +22,9 @@ const Navigation: React.FC<NavigationProps> = () => {
         >
           <AppLogo />
         </Button>
-        <UserDisplay />
+        <div className="ml-auto">
+          <UserDisplay />
+        </div>
       </div>
     </div>
   );

--- a/packages/frontend/src/components/common/layout/Navigation.tsx
+++ b/packages/frontend/src/components/common/layout/Navigation.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { Button } from '@nextui-org/react';
 import AppLogo from '../util/AppLogo';
 import UserDisplay from '../util/UserDisplay';
@@ -11,11 +11,11 @@ interface NavigationProps {
 
 const Navigation: React.FC<NavigationProps> = ({ backpath }) => {
   const navigate = useNavigate();
-  const location = useLocation();
 
   return (
-    <div className="p-4 mb-8 shadow bg-slate-50">
-      <div className="flex items-center justify-between mx-10">
+    <div className="p-4 shadow mb-8">
+      <div className="flex justify-between mx-10">
+        <BackButton backpath={backpath} />
         <Button
           className="w-auto h-auto bg-transparent"
           onClick={() => navigate('/dashboard')}

--- a/packages/frontend/src/components/common/layout/Page.tsx
+++ b/packages/frontend/src/components/common/layout/Page.tsx
@@ -2,12 +2,14 @@ import React from 'react';
 import Footer from './Footer';
 import Navigation from './Navigation';
 
-interface PageProps {}
+interface PageProps {
+  backpath?: string;
+}
 
 /**
  * Generic page used by pages in the app (i.e. not public pages)
  */
-const Page: React.FC<PageProps> = ({ children }) => {
+const Page: React.FC<PageProps> = ({ children, backpath }) => {
   return (
     <div className="flex flex-col w-full min-h-screen bg-gray-50">
       <div className="sticky top-0 z-50">

--- a/packages/frontend/src/components/common/util/BackButton.tsx
+++ b/packages/frontend/src/components/common/util/BackButton.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Button } from '@nextui-org/react';
+import { useNavigate } from 'react-router-dom';
+import { ChevronLeftIcon } from '@heroicons/react/outline';
+
+interface BackButtonProps {
+  backpath?: string;
+}
+
+const BackButton: React.FC<BackButtonProps> = ({ backpath }) => {
+  const navigate = useNavigate();
+
+  return (
+    <div>
+      {backpath && (
+        <Button
+          onClick={() => navigate(backpath)}
+          className="flex justify-center items-center py-3 h-fit -ml-11 mr-2 hover:bg-gray-700 hover:bg-opacity-5 transition-all"
+          auto
+          light
+          icon={<ChevronLeftIcon className="w-10" />}
+        />
+      )}
+    </div>
+  );
+};
+
+export default BackButton;

--- a/packages/frontend/src/pages/private/BillDetailPage.tsx
+++ b/packages/frontend/src/pages/private/BillDetailPage.tsx
@@ -141,7 +141,7 @@ const BillDetailPage: React.FC<BillDetailPageProps> = () => {
   const fileNotAttached = image === null || image === undefined;
 
   return (
-    <Page>
+    <Page backpath="/bills">
       {isEdit ? (
         <div className="px-10 pt-10 md:px-20">
           <EditBillCard

--- a/packages/frontend/src/pages/private/BillSplittingPage.tsx
+++ b/packages/frontend/src/pages/private/BillSplittingPage.tsx
@@ -102,7 +102,7 @@ const BillSplittingPage: React.FC<BillSplittingPageProps> = () => {
     [data],
   );
   return (
-    <Page>
+    <Page backpath="/dashboard">
       <div className="flex flex-col gap-4">
         <Button
           aria-label="New bill"

--- a/packages/frontend/src/pages/private/IssueDetailPage.tsx
+++ b/packages/frontend/src/pages/private/IssueDetailPage.tsx
@@ -141,7 +141,7 @@ const IssueDetailPage: React.FC<IssueDetailPageProps> = () => {
   };
 
   return (
-    <Page>
+    <Page backpath="/issues">
       {isEdit ? (
         <div className="px-10 pt-10 md:px-20">
           <EditIssueCard

--- a/packages/frontend/src/pages/private/IssuesPage.tsx
+++ b/packages/frontend/src/pages/private/IssuesPage.tsx
@@ -74,7 +74,7 @@ const IssuesPage: React.FC<IssuesPageProps> = () => {
   );
 
   return (
-    <Page>
+    <Page backpath="/dashboard">
       <div className="flex flex-col gap-4">
         <Button
           aria-label="New Issue"

--- a/packages/frontend/src/pages/private/NotesPage.tsx
+++ b/packages/frontend/src/pages/private/NotesPage.tsx
@@ -16,7 +16,7 @@ const NotesPage: React.FC<NotesProps> = () => {
   const createNoteHandler = () => setCreateNoteVisible(true);
 
   return (
-    <Page>
+    <Page backpath="/dashboard">
       <div className="flex justify-between items-center pb-1">
         <UnderlinedText colorClasses="from-gray-800 via-teal-700 to-teal-500 ">
           <div className="text-2xl font-medium">


### PR DESCRIPTION
# Description

Adds a back button to implemented pages that takes the user to intended routes.
The button is hidden unless a backpath is specified.

Fixes/resolves #154

## Screenshots

https://user-images.githubusercontent.com/57572181/161354182-81e7821c-5b13-4a36-a4fa-b793954affa1.mp4

## Type of change

- [x] **New feature** (non-breaking change which adds functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)

# Checklist:

Leave blank if not applicable

I have completed these steps when making this pull request:

- [x] I have assigned my name to the issue
- [x] I have moved the issue to the **In Progress** column
- [x] I have labelled the PR appropriately
- [x] I have assigned myself to the PR

Before opening the PR for review:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added attributions to new dependencies and resources
- [x] I have moved the linked issue to the **Review in Progress** column
