### PR TITLE
Add a back button to existing pages

### DIFF
--- a/packages/backend/src/controllers/house/dto/house-response.dto.ts
+++ b/packages/backend/src/controllers/house/dto/house-response.dto.ts
@@ -10,9 +10,9 @@ export default class HouseResponseDto {
   @ApiPropertyOptional()
   address: string;
   @ApiPropertyOptional()
-  rent: string;
+  rent: number;
   @ApiPropertyOptional()
-  maxOccupants: string;
+  maxOccupants: number;
   @ApiProperty({ required: true })
   code: string;
   @ApiProperty({ required: true })

--- a/packages/backend/src/controllers/house/dto/update-house.dto.ts
+++ b/packages/backend/src/controllers/house/dto/update-house.dto.ts
@@ -8,9 +8,9 @@ export default class UpdateHouseDto {
   @ApiPropertyOptional()
   address: string;
   @ApiPropertyOptional()
-  rent: string;
+  rent: number;
   @ApiPropertyOptional()
-  maxOccupants: string;
+  maxOccupants: number;
   @ApiProperty({ required: true })
   code: string;
   @ApiPropertyOptional()

--- a/packages/backend/src/controllers/issues/issues.controller.ts
+++ b/packages/backend/src/controllers/issues/issues.controller.ts
@@ -86,7 +86,7 @@ export class IssueController {
     const issueModel: IssueModel = {
       name: createIssueDto.name,
       description: createIssueDto.description,
-      image: createIssueDto.image,
+      image: createIssueDto.image ? createIssueDto.image : undefined, //Sets image to undefined if null so that default value will be set
       house: logger.house,
       logger: logger._id,
       loggedDate: currentDate,

--- a/packages/backend/src/controllers/note/note.controller.ts
+++ b/packages/backend/src/controllers/note/note.controller.ts
@@ -70,7 +70,7 @@ export class NoteController {
   @ApiBadRequestResponse({ description: 'user does not belong to a house' })
   @ApiOkResponse({
     description: 'notes retrieved successfully',
-    type: [NoteResponseDto],
+    type: NotesResponseDto,
   })
   async get(@User() user: DecodedIdToken): Promise<NotesResponseDto> {
     const userDoc = await this.userStoreService.findOneByFirebaseId(user.uid);

--- a/packages/backend/src/db/house/house.schema.ts
+++ b/packages/backend/src/db/house/house.schema.ts
@@ -15,10 +15,10 @@ export class House {
   address: string;
 
   @Prop()
-  rent: string;
+  rent: number;
 
   @Prop()
-  maxOccupants: string;
+  maxOccupants: number;
 
   @Prop({ unique: true })
   code: string;
@@ -39,8 +39,8 @@ export class HouseModel {
   readonly name: string;
   readonly email: string;
   readonly address: string;
-  rent: string;
-  maxOccupants: string;
+  rent: number;
+  maxOccupants: number;
   code: string;
   owner: Types.ObjectId;
   users: Array<Types.ObjectId> = [];

--- a/packages/backend/src/db/house/houseStore.service.spec.ts
+++ b/packages/backend/src/db/house/houseStore.service.spec.ts
@@ -87,8 +87,8 @@ describe('HouseStoreService', () => {
       email: 'whatever@gmail.com',
       address: 'Mars',
       code: 'lol',
-      rent: '1000',
-      maxOccupants: '3',
+      rent: 1000,
+      maxOccupants: 3,
       owner: null,
       users: [],
     });

--- a/packages/frontend/src/components/common/layout/Navigation.tsx
+++ b/packages/frontend/src/components/common/layout/Navigation.tsx
@@ -1,23 +1,29 @@
 import React from 'react';
-import AppLogo from '../util/AppLogo';
-import UserDisplay from '../util/UserDisplay';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '@nextui-org/react';
+import AppLogo from '../util/AppLogo';
+import UserDisplay from '../util/UserDisplay';
+import BackButton from '../util/BackButton';
 
-interface NavigationProps {}
+interface NavigationProps {
+  backpath?: string;
+}
 
-const Navigation: React.FC<NavigationProps> = () => {
+const Navigation: React.FC<NavigationProps> = ({ backpath }) => {
   const navigate = useNavigate();
   return (
     <div className="p-4 mb-8 shadow bg-slate-50">
       <div className="flex items-center justify-between mx-10">
+        <BackButton backpath={backpath} />
         <Button
           className="w-auto h-auto bg-transparent"
           onClick={() => navigate('/dashboard')}
         >
           <AppLogo />
         </Button>
-        <UserDisplay />
+        <div className="ml-auto">
+          <UserDisplay />
+        </div>
       </div>
     </div>
   );

--- a/packages/frontend/src/components/common/layout/Page.tsx
+++ b/packages/frontend/src/components/common/layout/Page.tsx
@@ -2,16 +2,18 @@ import React from 'react';
 import Footer from './Footer';
 import Navigation from './Navigation';
 
-interface PageProps {}
+interface PageProps {
+  backpath?: string;
+}
 
 /**
  * Generic page used by pages in the app (i.e. not public pages)
  */
-const Page: React.FC<PageProps> = ({ children }) => {
+const Page: React.FC<PageProps> = ({ children, backpath }) => {
   return (
     <div className="flex flex-col w-full min-h-screen bg-gray-50">
       <div className="sticky top-0 z-50">
-        <Navigation />
+        <Navigation backpath={backpath} />
       </div>
 
       <div className="self-center flex-grow w-full max-w-5xl px-10">

--- a/packages/frontend/src/components/common/util/BackButton.tsx
+++ b/packages/frontend/src/components/common/util/BackButton.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Button } from '@nextui-org/react';
+import { useNavigate } from 'react-router-dom';
+import { ChevronLeftIcon } from '@heroicons/react/outline';
+
+interface BackButtonProps {
+  backpath?: string;
+}
+
+const BackButton: React.FC<BackButtonProps> = ({ backpath }) => {
+  const navigate = useNavigate();
+
+  return (
+    <div>
+      {backpath && (
+        <Button
+          onClick={() => navigate(backpath)}
+          className="flex justify-center items-center py-3 h-fit -ml-11 mr-2 hover:bg-gray-700 hover:bg-opacity-5 transition-all"
+          auto
+          light
+          icon={<ChevronLeftIcon className="w-10" />}
+        />
+      )}
+    </div>
+  );
+};
+
+export default BackButton;

--- a/packages/frontend/src/components/dashboard/QuickAccessPanel.tsx
+++ b/packages/frontend/src/components/dashboard/QuickAccessPanel.tsx
@@ -41,6 +41,7 @@ const QuickAccessPanel: React.FC<QuickAccessPanelProps> = () => {
         twGradientStart="from-purple-700"
         twGradientEnd="to-yellow-800"
         twOpacity="opacity-80"
+        onClick={() => navigate('/manage-flat')}
         description="Manage your flat's members and settings."
       />
       <TopAction

--- a/packages/frontend/src/components/issue/NewIssueCard.tsx
+++ b/packages/frontend/src/components/issue/NewIssueCard.tsx
@@ -1,6 +1,11 @@
 import { Button, Textarea } from '@nextui-org/react';
 import React, { useState } from 'react';
 import { useApiMutation } from '../../hooks/useApi';
+import { parseFileName } from '../../services/fileNameParser';
+import { getStorage, ref, uploadBytes, UploadResult } from 'firebase/storage';
+import { v4 as uuidv4 } from 'uuid';
+import { CloudUploadIcon } from '@heroicons/react/outline';
+import { useAlert } from '../../components/common/util/CornerAlert';
 
 interface NewIssueCardProps {
   refetchOptimisticIssues: (issue: any) => void;
@@ -11,6 +16,7 @@ interface Issue {
   title: string;
   detail: string;
   resolved: boolean;
+  image: File | null | undefined;
 }
 
 const NewIssueCard: React.FC<NewIssueCardProps> = ({
@@ -21,14 +27,17 @@ const NewIssueCard: React.FC<NewIssueCardProps> = ({
     title: '',
     detail: '',
     resolved: false,
+    image: undefined,
   });
 
   const createIssue = useApiMutation('/api/v1/house/issues', {
     method: 'post',
   });
 
+  const { createAlert } = useAlert();
+
   const handleDoneButton = async (e: React.MouseEvent<HTMLButtonElement>) => {
-    let issue = {
+    const issue = {
       name: issueInfo.title,
       description: issueInfo.detail,
       resolved: issueInfo.resolved,
@@ -39,9 +48,41 @@ const NewIssueCard: React.FC<NewIssueCardProps> = ({
       body: issue,
     };
 
+    if (issueInfo.image) {
+      createAlert({
+        icon: <CloudUploadIcon />,
+        message: 'Wait while image is being uploaded!',
+        mode: 'info',
+      });
+
+      try {
+        issue.image = (await uploadImage()).ref.name;
+
+        createAlert({
+          icon: <CloudUploadIcon />,
+          message: 'Upload Success!',
+          mode: 'info',
+        });
+      } catch (err) {
+        createAlert({
+          icon: <CloudUploadIcon />,
+          message: 'Image upload failed',
+          mode: 'info',
+        });
+      }
+    }
+
     refetchOptimisticIssues(issue);
     await createIssue(issueBody);
     refetchFromApi();
+  };
+
+  const uploadImage = async (): Promise<UploadResult> => {
+    const storage = getStorage();
+    const fileName = uuidv4(); // ⇨ '9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d'
+    const storageRef = ref(storage, fileName);
+
+    return uploadBytes(storageRef, issueInfo.image!, {});
   };
 
   return (
@@ -95,6 +136,30 @@ const NewIssueCard: React.FC<NewIssueCardProps> = ({
                   }))
                 }
               />
+            </div>
+            <div className="flex flex-col gap-y-0.5">
+              <div className="font-bold">Image</div>
+              <label
+                htmlFor="file-upload"
+                className="flex justify-center px-4 py-2 font-medium text-white transition-all bg-teal-500 rounded-full bold hover:bg-teal-400 h-fit w-fit"
+              >
+                <input
+                  id="file-upload"
+                  hidden
+                  type={'file'}
+                  onChange={(e) => {
+                    setIssueInfo((prev) => ({
+                      ...prev,
+                      image: e.currentTarget.files?.item(0),
+                    }));
+                  }}
+                ></input>
+                <span className="max-w-xs overflow-hidden text-right text-clip">
+                  {issueInfo.image
+                    ? parseFileName(issueInfo.image.name)
+                    : 'Select File'}
+                </span>
+              </label>
             </div>
           </div>
         </div>

--- a/packages/frontend/src/components/manage/HouseSettings.tsx
+++ b/packages/frontend/src/components/manage/HouseSettings.tsx
@@ -5,11 +5,10 @@ import {
   Col,
   Button,
   FormElement,
-  Text,
 } from '@nextui-org/react';
 import React, { useState } from 'react';
 
-interface HouseSettingsProps {
+export interface HouseSettingsProps {
   ownerView: boolean;
   houseName: string;
   totalRent?: number;
@@ -24,112 +23,97 @@ const HouseSettings: React.FC<HouseSettingsProps> = (props) => {
     useState<HouseSettingsProps>({ ...props });
 
   return (
-    <div style={{ margin: 'auto' }}>
-      <Text
-        size={24}
-        weight={'bold'}
-        color={'primary'}
-        className="ml-5 inline-block"
-      >
-        {houseSettingsData.houseName}
-        <div className="bg-black h-0.5 w-full" />
-      </Text>
-      <Container
-        xl
-        style={{ backgroundColor: '#1D2530' }}
-        className="rounded-xl p-6 mt-4"
-      >
-        <Row>
-          <Col>
-            <Input
-              label="Total Rent:"
-              type="number"
-              readOnly={!props.ownerView}
-              initialValue={props.totalRent ? props.totalRent.toString() : ''}
-              onChange={(e: React.ChangeEvent<FormElement>) => {
-                setHouseSettingsData({
-                  ...houseSettingsData,
-                  totalRent: Number(e.target.value),
-                });
-              }}
-              color="secondary"
-              labelRight={'$'}
-              width="60%"
-            />
-          </Col>
-          <Col>
-            <Input
-              label="Maximum occupancy:"
-              type="number"
-              readOnly={!props.ownerView}
-              initialValue={
-                props.maxNumOccupants ? props.maxNumOccupants.toString() : ''
-              }
-              onChange={(e: React.ChangeEvent<FormElement>) => {
-                setHouseSettingsData({
-                  ...houseSettingsData,
-                  maxNumOccupants: Number(e.target.value),
-                });
-              }}
-              color="secondary"
-              width="60%"
-            />
-          </Col>
-        </Row>
+    <Container xl className="rounded-xl p-6 mt-4 bg-gray-800">
+      <Row>
+        <Col>
+          <Input
+            label="Total Rent:"
+            type="number"
+            readOnly={!props.ownerView}
+            initialValue={props.totalRent ? props.totalRent.toString() : ''}
+            onChange={(e: React.ChangeEvent<FormElement>) => {
+              setHouseSettingsData({
+                ...houseSettingsData,
+                totalRent: Number(e.target.value),
+              });
+            }}
+            color="secondary"
+            labelRight={'$'}
+            width="60%"
+          />
+        </Col>
+        <Col>
+          <Input
+            label="Maximum occupancy:"
+            type="number"
+            readOnly={!props.ownerView}
+            initialValue={
+              props.maxNumOccupants ? props.maxNumOccupants.toString() : ''
+            }
+            onChange={(e: React.ChangeEvent<FormElement>) => {
+              setHouseSettingsData({
+                ...houseSettingsData,
+                maxNumOccupants: Number(e.target.value),
+              });
+            }}
+            color="secondary"
+            width="60%"
+          />
+        </Col>
+      </Row>
 
-        <Row className="mt-4">
-          <Col>
-            <Input
-              label="Address:"
-              type="text"
-              readOnly={!props.ownerView}
-              initialValue={props.address}
-              onChange={(e: React.ChangeEvent<FormElement>) => {
-                setHouseSettingsData({
-                  ...houseSettingsData,
-                  address: e.target.value,
-                });
-              }}
-              color="secondary"
-              width="60%"
-            />
-          </Col>
+      <Row className="mt-4">
+        <Col>
+          <Input
+            label="Address:"
+            type="text"
+            readOnly={!props.ownerView}
+            initialValue={props.address}
+            onChange={(e: React.ChangeEvent<FormElement>) => {
+              setHouseSettingsData({
+                ...houseSettingsData,
+                address: e.target.value,
+              });
+            }}
+            color="secondary"
+            width="60%"
+          />
+        </Col>
 
-          <Col>
-            <Input
-              label="Owner Contact Number:"
-              type="text"
-              readOnly={!props.ownerView}
-              initialValue={props.ownerContactNum}
-              onChange={(e: React.ChangeEvent<FormElement>) => {
-                setHouseSettingsData({
-                  ...houseSettingsData,
-                  ownerContactNum: e.target.value,
-                });
-              }}
-              color="secondary"
-              width="60%"
-            />
-          </Col>
-        </Row>
+        <Col>
+          <Input
+            label="Owner Contact Number:"
+            type="text"
+            readOnly={!props.ownerView}
+            initialValue={props.ownerContactNum}
+            onChange={(e: React.ChangeEvent<FormElement>) => {
+              setHouseSettingsData({
+                ...houseSettingsData,
+                ownerContactNum: e.target.value,
+              });
+            }}
+            color="secondary"
+            width="60%"
+          />
+        </Col>
+      </Row>
 
-        <div className="flex justify-end mt-12 mr-5 ">
-          {props.ownerView && (
-            <>
-              <Button
-                disabled={!props.ownerView}
-                onClick={() => {
-                  props.onUpdateHouse(houseSettingsData);
-                }}
-                className="inline-block ml-4 bg-btn_green"
-              >
-                Save
-              </Button>
-            </>
-          )}
-        </div>
-      </Container>
-    </div>
+      <div className="flex justify-end mt-12 mr-5 ">
+        {props.ownerView && (
+          <>
+            <Button
+              disabled={!props.ownerView}
+              onClick={() => {
+                props.onUpdateHouse(houseSettingsData);
+              }}
+              className="inline-block ml-4 bg-btn_green"
+            >
+              Save
+            </Button>
+          </>
+        )}
+      </div>
+    </Container>
   );
 };
 

--- a/packages/frontend/src/components/manage/OccupantCard.tsx
+++ b/packages/frontend/src/components/manage/OccupantCard.tsx
@@ -7,20 +7,18 @@ export interface OccupantCardProps {
   name: string;
   firebaseId: string;
   contact?: string;
-  percentageOfRent?: number;
+  rentPercentage?: number;
   dateJoined?: Date;
-  contractEndDate?: Date;
+  contractEndingDate?: Date;
 }
 
 const OccupantCard: React.FC<OccupantCardProps> = (props) => {
   const { totalRent } = useContext(PanelContext);
 
   const OccupantSummary: React.FC = () => {
-    const rentToPay = (
-      totalRent *
-      (props.percentageOfRent || 0) *
-      0.01
-    ).toFixed(2);
+    const rentToPay = (totalRent * (props.rentPercentage || 0) * 0.01).toFixed(
+      2,
+    );
     return (
       <>
         <Text color={'secondary'} size={20}>
@@ -35,12 +33,11 @@ const OccupantCard: React.FC<OccupantCardProps> = (props) => {
 
   return (
     <>
-      <Collapse.Group splitted>
+      <Collapse.Group splitted style={{ padding: 0 }}>
         <Collapse
           // background color cannot be overridden with css prop nor tailwind className
           style={{ backgroundColor: '#1D2530' }}
           title={<OccupantSummary />}
-          css={{ size: '$tiny' }}
         >
           <OccupantForm {...props} />
         </Collapse>

--- a/packages/frontend/src/components/manage/OccupantForm.tsx
+++ b/packages/frontend/src/components/manage/OccupantForm.tsx
@@ -16,11 +16,13 @@ export const InputContext = React.createContext<InputContextInterface>(
 
 const OccupantForm: React.FC<OccupantCardProps> = (props) => {
   const [percentage, setPercentage] = useState<number>(
-    props.percentageOfRent || 0,
+    props.rentPercentage || 0,
   );
   const [contact, setContact] = useState<string>(props.contact || '');
   const [joinDate, setJoinDate] = useState<Date>(props.dateJoined as Date);
-  const [endDate, setEndDate] = useState<Date>(props.contractEndDate as Date);
+  const [endDate, setEndDate] = useState<Date>(
+    props.contractEndingDate as Date,
+  );
 
   const { ownerView, onSaveOccupant, onDeleteOccupant } =
     useContext(PanelContext);
@@ -33,7 +35,7 @@ const OccupantForm: React.FC<OccupantCardProps> = (props) => {
           </Text>
           <Input
             readOnly={!ownerView}
-            initialValue={props.percentageOfRent?.toString()}
+            initialValue={props.rentPercentage?.toString()}
             aria-label={'Percentage of rent to pay'}
             onChange={(e) => setPercentage(Number(e.target.value))}
             color="secondary"
@@ -96,9 +98,9 @@ const OccupantForm: React.FC<OccupantCardProps> = (props) => {
               onClick={() => {
                 const newOccupantData: OccupantCardProps = { ...props };
                 newOccupantData.contact = contact;
-                newOccupantData.contractEndDate = endDate;
+                newOccupantData.contractEndingDate = endDate;
                 newOccupantData.dateJoined = joinDate;
-                newOccupantData.percentageOfRent = percentage;
+                newOccupantData.rentPercentage = percentage;
                 onSaveOccupant(newOccupantData);
               }}
               className="inline-block ml-4 bg-btn_green"

--- a/packages/frontend/src/components/manage/OccupantPanel.tsx
+++ b/packages/frontend/src/components/manage/OccupantPanel.tsx
@@ -1,4 +1,3 @@
-import { Text } from '@nextui-org/react';
 import React from 'react';
 import OccupantCard, { OccupantCardProps } from './OccupantCard';
 
@@ -28,17 +27,8 @@ const OccupantPanel: React.FC<OccupantPanelProps> = (props) => {
     <PanelContext.Provider
       value={{ ownerView, totalRent, onSaveOccupant, onDeleteOccupant }}
     >
-      <Text
-        size={24}
-        weight={'bold'}
-        color={'primary'}
-        className="ml-5 inline-block"
-      >
-        Occupants
-        <div className="bg-black h-0.5 w-full" />
-      </Text>
       {cards.map((card) => (
-        <OccupantCard {...card} />
+        <OccupantCard {...card} key={card.firebaseId} />
       ))}
     </PanelContext.Provider>
   );

--- a/packages/frontend/src/components/notes/note/editButton.tsx
+++ b/packages/frontend/src/components/notes/note/editButton.tsx
@@ -10,6 +10,7 @@ interface EditButtonProps {
   setValue: (value: string) => void;
   activeType: string;
   activeId: string;
+  setVisibleModal: (value: boolean) => void;
 }
 
 const EditButton: React.FC<EditButtonProps> = ({
@@ -19,6 +20,7 @@ const EditButton: React.FC<EditButtonProps> = ({
   setValue,
   activeType,
   activeId,
+  setVisibleModal,
 }) => {
   const [editNoteVisible, setEditNoteVisible] = useState(false);
   const editNoteHandler = () => setEditNoteVisible(true);
@@ -42,6 +44,7 @@ const EditButton: React.FC<EditButtonProps> = ({
         activeId={activeId}
         editNoteVisible={editNoteVisible}
         setEditNoteVisible={setEditNoteVisible}
+        setVisibleModal={setVisibleModal}
       />
     </div>
   );

--- a/packages/frontend/src/components/notes/note/newNoteModal.tsx
+++ b/packages/frontend/src/components/notes/note/newNoteModal.tsx
@@ -52,10 +52,20 @@ const NewNoteModal: React.FC<NewNoteModalProps> = ({
     type: "PLAIN" | "SECRET" | "WIFI";
   }
 
+  interface NewWifiDetails {
+    username: string;
+    passward: string;
+  }
+
   const [newNoteDetails, setNoteDetails] = useState<NewNoteDetails>({
     name: '',
     value: '',
     type: NoteTypes.PLAIN,
+  });
+
+  const [newWifiDetails, setWifiDetails] = useState<NewWifiDetails>({
+    username: '',
+    passward: '',
   });
 
   // const { data, mutate } = useApi('/api/v1/house/note', { method: 'get' });
@@ -64,6 +74,9 @@ const NewNoteModal: React.FC<NewNoteModalProps> = ({
 
   async function onClickCreate() {
     try {
+      if (newNoteDetails.type===NoteTypes.WIFI){
+        newNoteDetails.value = newWifiDetails.username + " + " + newWifiDetails.passward;
+      }
       const { name, value, type } = newNoteDetails;
       await createNote({ body: { name, value, type } });
       // mutate();
@@ -191,6 +204,12 @@ const NewNoteModal: React.FC<NewNoteModalProps> = ({
               placeholder="Enter the username"
               size="xl"
               color="primary"
+              onChange={(e) =>
+                setWifiDetails((prevState) => ({
+                  ...prevState,
+                  username: e.target.value,
+                }))
+              }
             ></Input>
             <Text size={'1.25rem'} margin="1.5%">
               Password
@@ -202,6 +221,12 @@ const NewNoteModal: React.FC<NewNoteModalProps> = ({
               placeholder="Enter the password"
               size="xl"
               color="primary"
+              onChange={(e) =>
+                setWifiDetails((prevState) => ({
+                  ...prevState,
+                  passward: e.target.value,
+                }))
+              }
             ></Input>
           </Container>
         ) : null}

--- a/packages/frontend/src/components/notes/note/newNoteModal.tsx
+++ b/packages/frontend/src/components/notes/note/newNoteModal.tsx
@@ -10,8 +10,7 @@ import {
   Text,
   Textarea,
 } from '@nextui-org/react';
-import { useApiMutation } from '../../../hooks/useApi';
-// import { useNavigate } from 'react-router-dom';
+import { useApi, useApiMutation } from '../../../hooks/useApi';
 
 const NORMAL_TYPE = 'Normal';
 const SECRET_TYPE = 'Secret';
@@ -49,12 +48,12 @@ const NewNoteModal: React.FC<NewNoteModalProps> = ({
   interface NewNoteDetails {
     name: string;
     value: string;
-    type: "PLAIN" | "SECRET" | "WIFI";
+    type: 'PLAIN' | 'SECRET' | 'WIFI';
   }
 
   interface NewWifiDetails {
     username: string;
-    passward: string;
+    password: string;
   }
 
   const [newNoteDetails, setNoteDetails] = useState<NewNoteDetails>({
@@ -65,21 +64,22 @@ const NewNoteModal: React.FC<NewNoteModalProps> = ({
 
   const [newWifiDetails, setWifiDetails] = useState<NewWifiDetails>({
     username: '',
-    passward: '',
+    password: '',
   });
 
-  // const { data, mutate } = useApi('/api/v1/house/note', { method: 'get' });
+  const { mutate } = useApi('/api/v1/house/note', { method: 'get' });
 
   const createNote = useApiMutation('/api/v1/house/note', { method: 'post' });
 
   async function onClickCreate() {
     try {
-      if (newNoteDetails.type===NoteTypes.WIFI){
-        newNoteDetails.value = newWifiDetails.username + " + " + newWifiDetails.passward;
+      if (newNoteDetails.type === NoteTypes.WIFI) {
+        newNoteDetails.value =
+          newWifiDetails.username + ':' + newWifiDetails.password;
       }
       const { name, value, type } = newNoteDetails;
       await createNote({ body: { name, value, type } });
-      // mutate();
+      mutate();
       setCreateNoteVisible(false);
     } catch (e) {}
   }
@@ -127,18 +127,21 @@ const NewNoteModal: React.FC<NewNoteModalProps> = ({
             else setShowWifiInputs(false);
             if (e.name === SECRET_TYPE) setShowSecretInputs(true);
             else setShowSecretInputs(false);
-            if (e.name === NORMAL_TYPE) setNoteDetails((prevState) => ({
-              ...prevState,
-              type: NoteTypes.PLAIN,
-            }));
-            if (e.name === WIFI_TYPE) setNoteDetails((prevState) => ({
-              ...prevState,
-              type: NoteTypes.WIFI,
-            }));
-            if (e.name === SECRET_TYPE) setNoteDetails((prevState) => ({
-              ...prevState,
-              type: NoteTypes.SECRET,
-            }));
+            if (e.name === NORMAL_TYPE)
+              setNoteDetails((prevState) => ({
+                ...prevState,
+                type: NoteTypes.PLAIN,
+              }));
+            if (e.name === WIFI_TYPE)
+              setNoteDetails((prevState) => ({
+                ...prevState,
+                type: NoteTypes.WIFI,
+              }));
+            if (e.name === SECRET_TYPE)
+              setNoteDetails((prevState) => ({
+                ...prevState,
+                type: NoteTypes.SECRET,
+              }));
           }}
         >
           <div className="relative mt-1">
@@ -224,7 +227,7 @@ const NewNoteModal: React.FC<NewNoteModalProps> = ({
               onChange={(e) =>
                 setWifiDetails((prevState) => ({
                   ...prevState,
-                  passward: e.target.value,
+                  password: e.target.value,
                 }))
               }
             ></Input>

--- a/packages/frontend/src/components/notes/note/noteCardController.tsx
+++ b/packages/frontend/src/components/notes/note/noteCardController.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { Button } from '@nextui-org/react';
 import NotesModal from './NotesGrid';
-import { useApi, useApiMutation } from '../../../hooks/useApi';
+import { useApi } from '../../../hooks/useApi';
 
 interface NoteCardControllerProps {}
 
@@ -12,30 +11,11 @@ export enum NoteTypes {
 }
 
 const NoteCardController: React.FC<NoteCardControllerProps> = () => {
-  const { data, mutate } = useApi('/api/v1/house/note', { method: 'get' });
-
-  const createNote = useApiMutation('/api/v1/house/note', { method: 'post' });
-
-  // temp data to test api fetch works
-  const newNoteTestDetails = {
-    name: 'note2',
-    value: 'this is the value',
-    type: NoteTypes.PLAIN,
-  };
-
-  // temp to be linked to actual create note button
-  async function onClickTest() {
-    try {
-      const { name, value, type } = newNoteTestDetails;
-      await createNote({ body: { name, value, type } });
-      mutate();
-    } catch (e) {}
-  }
+  const { data } = useApi('/api/v1/house/note', { method: 'get' });
 
   return (
     <div>
       <NotesModal notes={data?.notes} />
-      <Button onClick={onClickTest}>Test</Button>
     </div>
   );
 };

--- a/packages/frontend/src/components/notes/note/plainModal.tsx
+++ b/packages/frontend/src/components/notes/note/plainModal.tsx
@@ -70,6 +70,7 @@ const PlainModal: React.FC<PlainModalProps> = ({
                 setValue={setValue}
                 activeType={NoteTypes.PLAIN}
                 activeId={id}
+                setVisibleModal={setVisible}
               />
             )}
           </Container>

--- a/packages/frontend/src/components/notes/note/secretModal.tsx
+++ b/packages/frontend/src/components/notes/note/secretModal.tsx
@@ -79,6 +79,7 @@ const SecretModal: React.FC<SecretModalProps> = ({
                 setValue={setValue}
                 activeType={NoteTypes.SECRET}
                 activeId={id}
+                setVisibleModal={setVisible}
               />
             )}
           </Container>

--- a/packages/frontend/src/components/notes/note/wifiModal.tsx
+++ b/packages/frontend/src/components/notes/note/wifiModal.tsx
@@ -116,6 +116,7 @@ const WifiModal: React.FC<WifiModalProps> = ({
                 setValue={setValue}
                 activeType={NoteTypes.WIFI}
                 activeId={id}
+                setVisibleModal={setVisible}
               />
             )}
           </Container>
@@ -143,13 +144,14 @@ const WifiModal: React.FC<WifiModalProps> = ({
                     label="Username"
                     readOnly
                     width="86%"
-                    initialValue={value.substring(0, value.indexOf(' + '))}
+                    value={value.substring(0, value.indexOf(':'))}
                   />
                   <Input
                     label="Password"
+                    readOnly
                     width="86%"
                     type={passwordShown ? 'text' : 'password'}
-                    initialValue={value.substring(value.indexOf(' + ') + 3)}
+                    value={value.substring(value.indexOf(':') + 1)}
                   />
                   {unHideButton()}
                 </Container>

--- a/packages/frontend/src/components/notes/note/wifiModal.tsx
+++ b/packages/frontend/src/components/notes/note/wifiModal.tsx
@@ -143,13 +143,13 @@ const WifiModal: React.FC<WifiModalProps> = ({
                     label="Username"
                     readOnly
                     width="86%"
-                    initialValue={value.substring(0, value.indexOf(':'))}
+                    initialValue={value.substring(0, value.indexOf(' + '))}
                   />
                   <Input
                     label="Password"
                     width="86%"
                     type={passwordShown ? 'text' : 'password'}
-                    initialValue={value.substring(value.indexOf(':') + 1)}
+                    initialValue={value.substring(value.indexOf(' + ') + 3)}
                   />
                   {unHideButton()}
                 </Container>

--- a/packages/frontend/src/hooks/useHouse.tsx
+++ b/packages/frontend/src/hooks/useHouse.tsx
@@ -7,6 +7,12 @@ interface House {
   address: string;
   code: string;
   owner: string;
+  latestAnnouncement?: {
+    author: string;
+    dateCreated: string;
+    description?: string;
+    title?: string;
+  };
 
   users: {
     name: string;

--- a/packages/frontend/src/hooks/useHouse.tsx
+++ b/packages/frontend/src/hooks/useHouse.tsx
@@ -7,6 +7,8 @@ interface House {
   address: string;
   code: string;
   owner: string;
+  maxOccupants: number;
+  rent: number;
   latestAnnouncement?: {
     author: string;
     dateCreated: string;
@@ -18,6 +20,10 @@ interface House {
     name: string;
     house?: string;
     firebaseId: string;
+    contractEndingDate?: string;
+    rentPercentage?: number;
+    dateJoined?: string;
+    contact?: string;
   }[];
 }
 

--- a/packages/frontend/src/pages/private/AnnouncementPage.tsx
+++ b/packages/frontend/src/pages/private/AnnouncementPage.tsx
@@ -47,7 +47,7 @@ const AnnouncementPage: React.FC = () => {
   }, [data]);
 
   return (
-    <Page>
+    <Page backpath="/dashboard">
       <div>
         <Button className="rounded-lg" onClick={() => setModalVisible(true)}>
           New Announcement

--- a/packages/frontend/src/pages/private/BillDetailPage.tsx
+++ b/packages/frontend/src/pages/private/BillDetailPage.tsx
@@ -19,6 +19,7 @@ import { useHouse } from '../../hooks/useHouse';
 import { components } from '../../types/api-schema';
 import { ExternalLinkIcon } from '@heroicons/react/outline';
 import { useAlert } from '../../components/common/util/CornerAlert';
+import { parseFileName } from '../../services/fileNameParser';
 
 const getFirebaseUrl = (proofFileId: string) =>
   'https://firebasestorage.googleapis.com/v0/b/flatshare-c8e5c.appspot.com/o/' +
@@ -124,13 +125,6 @@ const BillDetailPage: React.FC<BillDetailPageProps> = () => {
         proof: proof,
       },
     });
-  };
-
-  const parseFileName = (fileName: String) => {
-    if (fileName.length < 22) {
-      return fileName;
-    }
-    return fileName.slice(0, 10) + '...' + fileName.slice(-10);
   };
 
   const deleteBill = async () => {

--- a/packages/frontend/src/pages/private/BillDetailPage.tsx
+++ b/packages/frontend/src/pages/private/BillDetailPage.tsx
@@ -141,7 +141,7 @@ const BillDetailPage: React.FC<BillDetailPageProps> = () => {
   const fileNotAttached = image === null || image === undefined;
 
   return (
-    <Page>
+    <Page backpath="/bills">
       {isEdit ? (
         <div className="px-10 pt-10 md:px-20">
           <EditBillCard

--- a/packages/frontend/src/pages/private/BillDetailPage.tsx
+++ b/packages/frontend/src/pages/private/BillDetailPage.tsx
@@ -135,7 +135,7 @@ const BillDetailPage: React.FC<BillDetailPageProps> = () => {
   const fileNotAttached = image === null || image === undefined;
 
   return (
-    <Page>
+    <Page backpath="/bills">
       {isEdit ? (
         <div className="px-10 pt-10 md:px-20">
           <EditBillCard

--- a/packages/frontend/src/pages/private/BillSplittingPage.tsx
+++ b/packages/frontend/src/pages/private/BillSplittingPage.tsx
@@ -102,7 +102,7 @@ const BillSplittingPage: React.FC<BillSplittingPageProps> = () => {
     [data],
   );
   return (
-    <Page>
+    <Page backpath="/dashboard">
       <div className="flex flex-col gap-4">
         <Button
           aria-label="New bill"

--- a/packages/frontend/src/pages/private/DashboardPage.tsx
+++ b/packages/frontend/src/pages/private/DashboardPage.tsx
@@ -1,19 +1,34 @@
 import React from 'react';
 import Page from '../../components/common/layout/Page';
+import DashboardAnnouncement from '../../components/dashboard/announcement/DashboardAnnouncement';
 import UnderlinedText from '../../components/dashboard/GradientUnderlinedText';
 import InviteButtonController from '../../components/dashboard/invite/InviteButtonController';
 import QuickAccessPanel from '../../components/dashboard/QuickAccessPanel';
 import NoUpcomingTasks from '../../components/dashboard/upcoming-tasks/NoUpcomingTasks';
 import UpcomingTask from '../../components/dashboard/upcoming-tasks/UpcomingTask';
 import { useHouse } from '../../hooks/useHouse';
+import { useNavigate } from 'react-router-dom';
 
 interface DashboardProps {}
 
 const DashboardPage: React.FC<DashboardProps> = () => {
-  const { name } = useHouse();
+  const navigate = useNavigate();
+
+  const { name, latestAnnouncement } = useHouse();
 
   return (
     <Page>
+      {latestAnnouncement && (
+        <DashboardAnnouncement
+          onViewAll={() => navigate('/announcement')}
+          title={latestAnnouncement.title || 'New Announcement'}
+          time={new Date(latestAnnouncement.dateCreated)}
+          user={latestAnnouncement.author}
+          description={
+            latestAnnouncement.description || 'No description provided.'
+          }
+        />
+      )}
       <div className="flex justify-between items-center pb-1">
         <UnderlinedText colorClasses="from-gray-800 via-teal-700 to-teal-500 ">
           <div className="text-lg font-medium">

--- a/packages/frontend/src/pages/private/IssueDetailPage.tsx
+++ b/packages/frontend/src/pages/private/IssueDetailPage.tsx
@@ -18,6 +18,7 @@ import { useHouse } from '../../hooks/useHouse';
 import { getStorage, ref, uploadBytes } from 'firebase/storage';
 import { v4 as uuidv4 } from 'uuid';
 import { useAlert } from '../../components/common/util/CornerAlert';
+import { parseFileName } from '../../services/fileNameParser';
 
 const getFirebaseUrl = (proofFileId: string) =>
   'https://firebasestorage.googleapis.com/v0/b/flatshare-c8e5c.appspot.com/o/' +
@@ -94,13 +95,6 @@ const IssueDetailPage: React.FC<IssueDetailPageProps> = () => {
   const deleteIssue = async () => {
     deleteIssueCall({ pathParams: { id: issue.id } });
     navigate('/issues', { replace: true });
-  };
-
-  const parseFileName = (fileName: String) => {
-    if (fileName.length < 22) {
-      return fileName;
-    }
-    return fileName.slice(0, 10) + '...' + fileName.slice(-10);
   };
 
   const fileNotAttached = image === null || image === undefined;

--- a/packages/frontend/src/pages/private/IssueDetailPage.tsx
+++ b/packages/frontend/src/pages/private/IssueDetailPage.tsx
@@ -141,7 +141,7 @@ const IssueDetailPage: React.FC<IssueDetailPageProps> = () => {
   };
 
   return (
-    <Page>
+    <Page backpath="/issues">
       {isEdit ? (
         <div className="px-10 pt-10 md:px-20">
           <EditIssueCard

--- a/packages/frontend/src/pages/private/IssueDetailPage.tsx
+++ b/packages/frontend/src/pages/private/IssueDetailPage.tsx
@@ -135,7 +135,7 @@ const IssueDetailPage: React.FC<IssueDetailPageProps> = () => {
   };
 
   return (
-    <Page>
+    <Page backpath="/issues">
       {isEdit ? (
         <div className="px-10 pt-10 md:px-20">
           <EditIssueCard

--- a/packages/frontend/src/pages/private/IssuesPage.tsx
+++ b/packages/frontend/src/pages/private/IssuesPage.tsx
@@ -74,7 +74,7 @@ const IssuesPage: React.FC<IssuesPageProps> = () => {
   );
 
   return (
-    <Page>
+    <Page backpath="/dashboard">
       <div className="flex flex-col gap-4">
         <Button
           aria-label="New Issue"

--- a/packages/frontend/src/pages/private/ManageFlatPage.tsx
+++ b/packages/frontend/src/pages/private/ManageFlatPage.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import Page from '../../components/common/layout/Page';
+import UnderlinedText from '../../components/dashboard/GradientUnderlinedText';
+import { useHouse } from '../../hooks/useHouse';
+import { useAuth } from '../../hooks/useAuth';
+import HouseSettings from '../../components/manage/HouseSettings';
+import OccupantPanel from '../../components/manage/OccupantPanel';
+import { OccupantCardProps } from '../../components/manage/OccupantCard';
+import LoaderPage from '../public/LoaderPage';
+import { useApiMutation } from '../../hooks/useApi';
+import { components } from '../../types/api-schema';
+import { HouseSettingsProps } from '../../components/manage/HouseSettings';
+
+interface ManageFlatPageProps {}
+
+const ManageFlatPage: React.FC<ManageFlatPageProps> = () => {
+  const house = useHouse();
+  const { user } = useAuth();
+
+  const saveHouseInfo = useApiMutation('/api/v1/house/update', {
+    method: 'put',
+  });
+
+  const updateOccupantInfo = useApiMutation('/api/v1/user', {
+    method: 'put',
+  });
+
+  const onSaveHouseInfo = async (data: HouseSettingsProps) => {
+    const newData: components['schemas']['UpdateHouseDto'] = {
+      code: house.code!,
+      address: data.address,
+      name: data.houseName,
+      maxOccupants: data.maxNumOccupants,
+      email: data.ownerContactNum,
+      rent: data.totalRent,
+    };
+    await saveHouseInfo({ body: newData });
+  };
+
+  const onSaveOccupants = async (occupantDetails: OccupantCardProps) => {
+    const newData: components['schemas']['UpdateUserDto'] = {
+      house: house.code!,
+      firebaseId: occupantDetails.firebaseId!,
+      name: occupantDetails.name,
+      rentPercentage: occupantDetails.rentPercentage,
+      contact: occupantDetails.contact,
+      //TODO update this once backend no longer strictly requires a date
+      dateJoined:
+        occupantDetails.dateJoined?.toDateString() ||
+        new Date(0).toDateString(),
+      contractEndingDate:
+        occupantDetails.contractEndingDate?.toDateString() ||
+        new Date(0).toDateString(),
+    };
+
+    console.log(newData);
+    await updateOccupantInfo({ body: newData });
+  };
+
+  const onDeleteOccupant = async (firebaseId: string) => {
+    if (!house || !house.users) {
+      console.log('Cannot access house, or users');
+      return;
+    }
+
+    await saveHouseInfo({
+      body: {
+        code: house.code!,
+        users: house.users
+          .map((user) => user.firebaseId)
+          .filter((id) => id !== firebaseId),
+      },
+    });
+  };
+
+  return (
+    <Page>
+      {house.dataLoading ? (
+        <LoaderPage />
+      ) : (
+        <div className="flex flex-col gap-4">
+          <UnderlinedText className="text-teal-500 " colorClasses="bg-gray-800">
+            <div className="text-lg font-semibold">
+              {house.name || 'Your Flat'}
+            </div>
+          </UnderlinedText>
+          <HouseSettings
+            ownerView={user?.uid === house.owner}
+            houseName={house.name || 'Your Flat'}
+            totalRent={house.rent}
+            maxNumOccupants={house.maxOccupants}
+            address={house.address}
+            ownerContactNum={house.email}
+            onUpdateHouse={onSaveHouseInfo}
+          />
+
+          <UnderlinedText
+            className="pt-10 text-teal-500 "
+            colorClasses="bg-gray-800"
+          >
+            <div className="text-lg font-semibold">Occupants</div>
+          </UnderlinedText>
+          <OccupantPanel
+            cards={
+              house.users
+                ? house.users?.map((u) => {
+                    return {
+                      name: u.name,
+                      firebaseId: u.firebaseId,
+                      contact: u.contact,
+                      rentPercentage: u.rentPercentage,
+                      dateJoined: u.dateJoined
+                        ? new Date(u.dateJoined)
+                        : undefined,
+                      contractEndingDate: u.contractEndingDate
+                        ? new Date(u.contractEndingDate)
+                        : undefined,
+                    };
+                  })
+                : []
+            }
+            ownerView={user?.uid === house.owner}
+            totalRent={house.rent || 0}
+            onSaveOccupant={onSaveOccupants}
+            onDeleteOccupant={onDeleteOccupant}
+          />
+        </div>
+      )}
+    </Page>
+  );
+};
+
+export default ManageFlatPage;

--- a/packages/frontend/src/pages/private/ManageFlatPage.tsx
+++ b/packages/frontend/src/pages/private/ManageFlatPage.tsx
@@ -74,7 +74,7 @@ const ManageFlatPage: React.FC<ManageFlatPageProps> = () => {
   };
 
   return (
-    <Page>
+    <Page backpath="/dashboard">
       {house.dataLoading ? (
         <LoaderPage />
       ) : (

--- a/packages/frontend/src/pages/private/NotesPage.tsx
+++ b/packages/frontend/src/pages/private/NotesPage.tsx
@@ -16,7 +16,7 @@ const NotesPage: React.FC<NotesProps> = () => {
   const createNoteHandler = () => setCreateNoteVisible(true);
 
   return (
-    <Page>
+    <Page backpath="/dashboard">
       <div className="flex justify-between items-center pb-1">
         <UnderlinedText colorClasses="from-gray-800 via-teal-700 to-teal-500 ">
           <div className="text-2xl font-medium">

--- a/packages/frontend/src/pages/routes/AuthenticatedRoutes.tsx
+++ b/packages/frontend/src/pages/routes/AuthenticatedRoutes.tsx
@@ -16,6 +16,7 @@ import {
   ExclamationCircleIcon,
   InformationCircleIcon,
 } from '@heroicons/react/outline';
+import ManageFlatPage from '../private/ManageFlatPage';
 import AnnouncementPage from '../private/AnnouncementPage';
 
 interface AuthenticatedRoutesProps {}
@@ -103,16 +104,13 @@ const AuthenticatedRoutes: React.FC<AuthenticatedRoutesProps> = () => {
         <Route index element={<BillSplittingPage />} />
         <Route path=":id" element={<BillDetailPage />} />
       </Route>
-      <Route path="notes">
-        <Route index element={<NotesPage />} />
-      </Route>
+      <Route path="manage-flat" element={<ManageFlatPage />} />
+      <Route path="notes" element={<NotesPage />} />
       <Route path="issues">
         <Route index element={<IssuesPage />} />
         <Route path=":id" element={<IssueDetailPage />} />
       </Route>
-      <Route path="announcement">
-        <Route index element={<AnnouncementPage />} />
-      </Route>
+      <Route path="announcement" element={<AnnouncementPage />} />
       <Route path="*" element={<Navigate to="/dashboard" replace />} />
     </Routes>
   );

--- a/packages/frontend/src/services/fileNameParser.ts
+++ b/packages/frontend/src/services/fileNameParser.ts
@@ -1,0 +1,8 @@
+const parseFileName = (fileName: String): String => {
+  if (fileName.length < 22) {
+    return fileName;
+  }
+  return fileName.slice(0, 10) + '...' + fileName.slice(-10);
+};
+
+export { parseFileName };

--- a/packages/frontend/src/types/api-schema.ts
+++ b/packages/frontend/src/types/api-schema.ts
@@ -242,6 +242,7 @@ export interface components {
       description: string;
       image: string;
       resolved: boolean;
+      image: string;
     };
     UpdateIssueDto: {
       name: string;

--- a/packages/frontend/src/types/api-schema.ts
+++ b/packages/frontend/src/types/api-schema.ts
@@ -132,8 +132,8 @@ export interface components {
       name?: string;
       email?: string;
       address?: string;
-      rent?: string;
-      maxOccupants?: string;
+      rent?: number;
+      maxOccupants?: number;
       code: string;
       owner: string;
       users: components['schemas']['UserResponseDto'][];
@@ -146,8 +146,8 @@ export interface components {
       name?: string;
       email?: string;
       address?: string;
-      rent?: string;
-      maxOccupants?: string;
+      rent?: number;
+      maxOccupants?: number;
       code: string;
       owner?: string;
       users?: string[];
@@ -242,7 +242,6 @@ export interface components {
       description: string;
       image: string;
       resolved: boolean;
-      image: string;
     };
     UpdateIssueDto: {
       name: string;


### PR DESCRIPTION
# Description

Adds a back button to implemented pages that takes the user to intended routes.
The button is hidden unless a backpath is specified.

Affected pages:
- [x] /billsplitting
- [x] /notes
- [x] /issues
- [x] /announcement
- [x] /manage-flat

Fixes/resolves #154

## Screenshots

https://user-images.githubusercontent.com/57572181/161354182-81e7821c-5b13-4a36-a4fa-b793954affa1.mp4

## Type of change

- [x] **New feature** (non-breaking change which adds functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)

# Checklist:

Leave blank if not applicable

I have completed these steps when making this pull request:

- [x] I have assigned my name to the issue
- [x] I have moved the issue to the **In Progress** column
- [x] I have labelled the PR appropriately
- [x] I have assigned myself to the PR

Before opening the PR for review:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added attributions to new dependencies and resources
- [x] I have moved the linked issue to the **Review in Progress** column
