### PR TITLE
Link up dashboard announcement card to api

### DIFF
--- a/packages/frontend/src/hooks/useHouse.tsx
+++ b/packages/frontend/src/hooks/useHouse.tsx
@@ -7,6 +7,12 @@ interface House {
   address: string;
   code: string;
   owner: string;
+  latestAnnouncement?: {
+    author: string;
+    dateCreated: string;
+    description?: string;
+    title?: string;
+  };
 
   users: {
     name: string;

--- a/packages/frontend/src/pages/private/DashboardPage.tsx
+++ b/packages/frontend/src/pages/private/DashboardPage.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Page from '../../components/common/layout/Page';
+import DashboardAnnouncement from '../../components/dashboard/announcement/DashboardAnnouncement';
 import UnderlinedText from '../../components/dashboard/GradientUnderlinedText';
 import InviteButtonController from '../../components/dashboard/invite/InviteButtonController';
 import QuickAccessPanel from '../../components/dashboard/QuickAccessPanel';
@@ -10,10 +11,23 @@ import { useHouse } from '../../hooks/useHouse';
 interface DashboardProps {}
 
 const DashboardPage: React.FC<DashboardProps> = () => {
-  const { name } = useHouse();
+  const { name, latestAnnouncement } = useHouse();
 
   return (
     <Page>
+      {latestAnnouncement && (
+        <DashboardAnnouncement
+          onViewAll={function (): void {
+            throw new Error('Function not implemented.');
+          }}
+          title={latestAnnouncement.title || 'New Announcement'}
+          time={new Date(latestAnnouncement.dateCreated)}
+          user={latestAnnouncement.author}
+          description={
+            latestAnnouncement.description || 'No description provided.'
+          }
+        />
+      )}
       <div className="flex justify-between items-center pb-1">
         <UnderlinedText colorClasses="from-gray-800 via-teal-700 to-teal-500 ">
           <div className="text-lg font-medium">

--- a/packages/frontend/src/pages/private/DashboardPage.tsx
+++ b/packages/frontend/src/pages/private/DashboardPage.tsx
@@ -7,19 +7,20 @@ import QuickAccessPanel from '../../components/dashboard/QuickAccessPanel';
 import NoUpcomingTasks from '../../components/dashboard/upcoming-tasks/NoUpcomingTasks';
 import UpcomingTask from '../../components/dashboard/upcoming-tasks/UpcomingTask';
 import { useHouse } from '../../hooks/useHouse';
+import { useNavigate } from 'react-router-dom';
 
 interface DashboardProps {}
 
 const DashboardPage: React.FC<DashboardProps> = () => {
+  const navigate = useNavigate();
+
   const { name, latestAnnouncement } = useHouse();
 
   return (
     <Page>
       {latestAnnouncement && (
         <DashboardAnnouncement
-          onViewAll={function (): void {
-            throw new Error('Function not implemented.');
-          }}
+          onViewAll={() => navigate('/announcement')}
           title={latestAnnouncement.title || 'New Announcement'}
           time={new Date(latestAnnouncement.dateCreated)}
           user={latestAnnouncement.author}


### PR DESCRIPTION
# Description

Subteam 1 added an announcements page. We want to display the latest announcement on the dashboard. The announcement pages and the dashboard announcement cards both exist, but the card is not currently connected to the dashboard. 
This PR adds the component to the dashboard and feeds it the necessary data from the API. Also connects routing

Fixes/resolves #196 

## Screenshots


https://user-images.githubusercontent.com/62003343/161362385-992f6502-76f0-4d79-a980-9a68c83002c5.mp4



## Type of change

Please delete options that are not relevant.

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

Leave blank if not applicable

I have completed these steps when making this pull request:

- [x] I have assigned my name to the issue
- [x] I have moved the issue to the **In Progress** column
- [x] I have labelled the PR appropriately
- [x] I have assigned myself to the PR

Before opening the PR for review:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added attributions to new dependencies and resources
- [x] I have moved the linked issue to the **Review in Progress** column
